### PR TITLE
Creates an custom command line argument parser for this project.

### DIFF
--- a/csv-log/command_line.py
+++ b/csv-log/command_line.py
@@ -1,0 +1,34 @@
+import argparse
+import logging
+from pathlib import Path
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+
+def create_csv_merge_argument_parser():
+    def path_type(path):
+        return Path(path) if path is not None else None
+
+    description = "Combine CSV report files NOT YET IMPLEMENTED"
+    log_levels = "critical error warning info debug notset".upper().split()
+    csv_merge_parser = argparse.ArgumentParser(description=description)
+    csv_merge_parser.add_argument("--input-directory", "-i",
+                                  help="Input directory, defaults to the current working directory",
+                                  type=path_type, default=Path.cwd())
+    csv_merge_parser.add_argument("--output-file", "-f",
+                                  help="The resulting combined CSV file, defaults to standard out",
+                                  type=path_type)
+    csv_merge_parser.add_argument("--backup-directory", "-b",
+                                  help="The backup directory, files are not moved if this argument is not present.",
+                                  type=path_type)
+    csv_merge_parser.add_argument("--log-level", "-l", choices=log_levels, default="WARN", type=str.upper,
+                                  help="Optional logging level")
+    return csv_merge_parser
+
+
+if __name__ == "__main__":
+    parser = create_csv_merge_argument_parser()
+    args = parser.parse_args()
+    logging.getLogger().setLevel(args.log_level)
+    logger.info(args)


### PR DESCRIPTION
This uses the _argparse_ module to create a custom command-line argument parser for this project.  Since this is an entry-point module for the project it configures the root logger level.  Otherwise, it does not yet do anything.

Resolves #13 